### PR TITLE
Fix lengow api url visibility

### DIFF
--- a/Model/Rewrite/Connector.php
+++ b/Model/Rewrite/Connector.php
@@ -40,7 +40,7 @@ class Connector extends \Lengow\Connector\Model\Connector
      * @var string url of the Lengow API
      */
     // const LENGOW_API_URL = 'https://api.lengow.io';
-    private const LENGOW_API_URL = 'https://api.lengow.net';
+    public const LENGOW_API_URL = 'https://api.lengow.net';
 
     /* Lengow API routes */
     public const API_ACCESS_TOKEN = '/access/get_token';

--- a/Model/Rewrite/Connector.php
+++ b/Model/Rewrite/Connector.php
@@ -434,7 +434,7 @@ class Connector extends \Lengow\Connector\Model\Connector
      *
      * @throws LengowException
      */
-    private function call(
+    protected function call(
         string $api,
         array $args = [],
         string $type = self::GET,
@@ -481,7 +481,7 @@ class Connector extends \Lengow\Connector\Model\Connector
      *
      * @throws LengowException
      */
-    private function callAction(string $api, array $args, string $type, string $format, string $body, bool $logOutput)
+    protected function callAction(string $api, array $args, string $type, string $format, string $body, bool $logOutput)
     {
         $result = $this->makeRequest($type, $api, $args, $this->token, $body, $logOutput);
         return $this->format($result, $format);
@@ -496,7 +496,7 @@ class Connector extends \Lengow\Connector\Model\Connector
      *
      * @throws LengowException
      */
-    private function getAuthorizationToken(bool $logOutput): string
+    protected function getAuthorizationToken(bool $logOutput): string
     {
         // reset temporary token for the new authorization
         $this->token = null;


### PR DESCRIPTION
Fix this errors on di compilation : 

`Fatal error: Access level to PH2M\LengowEnvironmentUrlsConfigurable\Model\Rewrite\Connector::getAuthorizationToken() must be protected (as in class Lengow\Connector\Model\Connector) or weaker in /var/www/html/vendor/ph2m/lengow-made-environment-urls-configurable/Model/Rewrite/Connector.php on line 499
{"messages":{"error":[{"code":500,"message":"Fatal Error: 'Access level to PH2M\\LengowEnvironmentUrlsConfigurable\\Model\\Rewrite\\Connector::getAuthorizationToken() must be protected (as in class Lengow\\Connector\\Model\\Connector) or weaker' in '\/var\/www\/html\/vendor\/ph2m\/lengow-made-environment-urls-configurable\/Model\/Rewrite\/Connector.php' on line 499","trace":"Trace is not available."}]}}ERROR: 255
`


With php 8.2 and lengow version 1.6.4.


